### PR TITLE
Make generated services easier to understand

### DIFF
--- a/grpc-kotlin-gen/src/main/java/io/rouz/grpc/kotlin/GrpcKotlinGenerator.java
+++ b/grpc-kotlin-gen/src/main/java/io/rouz/grpc/kotlin/GrpcKotlinGenerator.java
@@ -200,7 +200,7 @@ public class GrpcKotlinGenerator extends Generator {
 
   private PluginProtos.CodeGeneratorResponse.File buildServiceBaseImpl(Context context) {
     String content = applyTemplate("Service.mustache", context);
-    String fileName = context.serviceName + "Service.kt";
+    String fileName = context.serviceName + ".kt";
     return PluginProtos.CodeGeneratorResponse.File
       .newBuilder()
       .setName(absoluteFileName(context.packageName, fileName))

--- a/grpc-kotlin-gen/src/main/resources/Adapters.mustache
+++ b/grpc-kotlin-gen/src/main/resources/Adapters.mustache
@@ -117,9 +117,9 @@ annotation class CallScope
 @Retention(AnnotationRetention.BINARY)
 annotation class ForServices{ }
 
-data class RequestData(val metadata : Metadata)
+data class RequestData(val headers : Metadata)
 
-class GrpcKeepRequestDataInterceptor @Inject constructor() : ServerInterceptor {
+class KeepRequestDataInContextInterceptor @Inject constructor() : ServerInterceptor {
 
   override fun <ReqT, RespT> interceptCall(
     call: ServerCall<ReqT, RespT>,
@@ -134,11 +134,11 @@ class GrpcKeepRequestDataInterceptor @Inject constructor() : ServerInterceptor {
   companion object {
     private val requestDataKey = Context.key<RequestData>("grpcKotlinRequestData")
 
-    fun getKeptRequestData(): RequestData {
+    fun getRequestData(): RequestData {
       try {
         return requestDataKey.get()
       } catch (e: Throwable) {
-        throw IllegalStateException("No request data found. Have you added GrpcKeepRequestDataInterceptor to your interceptors?", e)
+        throw IllegalStateException("No request data found. Have you added KeepRequestDataInContextInterceptor to your interceptors?", e)
       }
     }
   }

--- a/grpc-kotlin-gen/src/main/resources/Adapters.mustache
+++ b/grpc-kotlin-gen/src/main/resources/Adapters.mustache
@@ -109,6 +109,8 @@ class GrpcContextCoroutineContextElement : ThreadContextElement<Context> {
         grpcContext.detach(oldState)
 }
 
+class GrpcContextWasCancelled : Throwable()
+
 @Scope
 @Retention(AnnotationRetention.RUNTIME)
 annotation class CallScope

--- a/grpc-kotlin-gen/src/main/resources/Service.mustache
+++ b/grpc-kotlin-gen/src/main/resources/Service.mustache
@@ -58,7 +58,7 @@ class {{serviceName}} @Inject constructor(
     final override fun {{methodName}}(request: {{inputType}}, responseObserver: StreamObserver<{{outputType}}>) {
         val requestData = GrpcKeepRequestDataInterceptor.getKeptRequestData()
         coroutineScope.launch(GrpcContextCoroutineContextElement()) {
-            this.doCancelScopeWhenGrpcContextCancelled()
+            cancelCoroutineScopeOnGrpcCancellation(scope = this)
             try {
                val handler = {{methodName}}ComponentFactory.create(requestData)
                       .provideHandler()
@@ -66,7 +66,7 @@ class {{serviceName}} @Inject constructor(
                responseObserver.onNext(response)
                responseObserver.onCompleted()
             } catch (t: Throwable) {
-               responseObserver.onError(t.orCancellationCause())
+               responseObserver.onError(t)
             }
         }
     }
@@ -81,7 +81,7 @@ class {{serviceName}} @Inject constructor(
     final override fun {{methodName}}(request: {{inputType}}, responseObserver: StreamObserver<{{outputType}}>) {
         val requestData = GrpcKeepRequestDataInterceptor.getKeptRequestData()
         coroutineScope.launch(GrpcContextCoroutineContextElement()) {
-            this.doCancelScopeWhenGrpcContextCancelled()
+            cancelCoroutineScopeOnGrpcCancellation(scope = this)
             try {
                val handler = {{methodName}}ComponentFactory.create(requestData)
                                  .provideHandler()
@@ -89,7 +89,7 @@ class {{serviceName}} @Inject constructor(
                   .consumeEach(responseObserver::onNext)
                responseObserver.onCompleted()
             } catch (t: Throwable) {
-               responseObserver.onError(t.orCancellationCause())
+               responseObserver.onError(t)
             }
         }
     }
@@ -108,13 +108,13 @@ class {{serviceName}} @Inject constructor(
     ): StreamObserver<{{inputType}}> {
         val requests = StreamObserverChannel<{{inputType}}>()
         coroutineScope.launch(GrpcContextCoroutineContextElement()) {
-            this.doCancelScopeWhenGrpcContextCancelled()
+            cancelCoroutineScopeOnGrpcCancellation(scope = this)
             try {
                val response = {{methodName}}(requests)
                responseObserver.onNext(response)
                responseObserver.onCompleted()
             } catch (t: Throwable) {
-               responseObserver.onError(t.orCancellationCause())
+               responseObserver.onError(t)
             }
         }
         return requests
@@ -131,7 +131,7 @@ class {{serviceName}} @Inject constructor(
     ): StreamObserver<{{inputType}}> {
         val requests = StreamObserverChannel<{{inputType}}>()
         coroutineScope.launch(GrpcContextCoroutineContextElement()) {
-            this.doCancelScopeWhenGrpcContextCancelled()
+            cancelCoroutineScopeOnGrpcCancellation(scope = this)
             try {
                val responses = {{methodName}}(requests)
                for (response in responses) {
@@ -139,7 +139,7 @@ class {{serviceName}} @Inject constructor(
                }
                responseObserver.onCompleted()
             } catch (t: Throwable) {
-               responseObserver.onError(t.orCancellationCause())
+               responseObserver.onError(t)
             }
         }
         return requests
@@ -152,19 +152,7 @@ class {{serviceName}} @Inject constructor(
         return Status.UNIMPLEMENTED
             .withDescription("Method ${methodDescriptor.fullMethodName} is unimplemented")
     }
-
-    private fun Throwable.orCancellationCause() : Throwable {
-       val _cause = this.cause
-       if (this is CancellationException && _cause != null) {
-          return _cause
-       }
-       return this
-    }
 }
 
-private fun CoroutineScope.doCancelScopeWhenGrpcContextCancelled() {
-  val onGrpcContextCancelled: (Context) -> Unit = {
-    cancel(CancellationException("Grpc context cancelled"))
-  }
-  Context.current().addListener(onGrpcContextCancelled, Runnable::run)
-}
+private fun cancelCoroutineScopeOnGrpcCancellation(scope: CoroutineScope) =
+  Context.current().addListener({ scope.cancel(CancellationException("Grpc context cancelled")) }, Runnable::run)

--- a/grpc-kotlin-gen/src/main/resources/Service.mustache
+++ b/grpc-kotlin-gen/src/main/resources/Service.mustache
@@ -56,10 +56,10 @@ class {{serviceName}} @Inject constructor(
     }
 
     final override fun {{methodName}}(request: {{inputType}}, responseObserver: StreamObserver<{{outputType}}>) {
-        val requestData = GrpcKeepRequestDataInterceptor.getKeptRequestData()
         coroutineScope.launch(GrpcContextCoroutineContextElement()) {
             cancelCoroutineScopeOnGrpcCancellation(scope = this)
             try {
+               val requestData = KeepRequestDataInContextInterceptor.getRequestData()
                val handler = {{methodName}}ComponentFactory.create(requestData)
                       .provideHandler()
                val response = handler.invoke(request)
@@ -79,10 +79,10 @@ class {{serviceName}} @Inject constructor(
     }
 
     final override fun {{methodName}}(request: {{inputType}}, responseObserver: StreamObserver<{{outputType}}>) {
-        val requestData = GrpcKeepRequestDataInterceptor.getKeptRequestData()
         coroutineScope.launch(GrpcContextCoroutineContextElement()) {
             cancelCoroutineScopeOnGrpcCancellation(scope = this)
             try {
+               val requestData = KeepRequestDataInContextInterceptor.getRequestData()
                val handler = {{methodName}}ComponentFactory.create(requestData)
                                  .provideHandler()
                produce<{{outputType}}> { handler.invoke(request, this) }

--- a/grpc-kotlin-gen/src/main/resources/Service.mustache
+++ b/grpc-kotlin-gen/src/main/resources/Service.mustache
@@ -57,8 +57,8 @@ class {{serviceName}} @Inject constructor(
 
     final override fun {{methodName}}(request: {{inputType}}, responseObserver: StreamObserver<{{outputType}}>) {
         coroutineScope.launch(GrpcContextCoroutineContextElement()) {
-            cancelCoroutineScopeOnGrpcCancellation(scope = this)
             try {
+               cancelCoroutineScopeOnGrpcCancellation(scope = this)
                val requestData = KeepRequestDataInContextInterceptor.getRequestData()
                val handler = {{methodName}}ComponentFactory.create(requestData)
                       .provideHandler()
@@ -80,8 +80,8 @@ class {{serviceName}} @Inject constructor(
 
     final override fun {{methodName}}(request: {{inputType}}, responseObserver: StreamObserver<{{outputType}}>) {
         coroutineScope.launch(GrpcContextCoroutineContextElement()) {
-            cancelCoroutineScopeOnGrpcCancellation(scope = this)
             try {
+               cancelCoroutineScopeOnGrpcCancellation(scope = this)
                val requestData = KeepRequestDataInContextInterceptor.getRequestData()
                val handler = {{methodName}}ComponentFactory.create(requestData)
                                  .provideHandler()
@@ -108,8 +108,8 @@ class {{serviceName}} @Inject constructor(
     ): StreamObserver<{{inputType}}> {
         val requests = StreamObserverChannel<{{inputType}}>()
         coroutineScope.launch(GrpcContextCoroutineContextElement()) {
-            cancelCoroutineScopeOnGrpcCancellation(scope = this)
             try {
+               cancelCoroutineScopeOnGrpcCancellation(scope = this)
                val response = {{methodName}}(requests)
                responseObserver.onNext(response)
                responseObserver.onCompleted()
@@ -131,8 +131,8 @@ class {{serviceName}} @Inject constructor(
     ): StreamObserver<{{inputType}}> {
         val requests = StreamObserverChannel<{{inputType}}>()
         coroutineScope.launch(GrpcContextCoroutineContextElement()) {
-            cancelCoroutineScopeOnGrpcCancellation(scope = this)
             try {
+               cancelCoroutineScopeOnGrpcCancellation(scope = this)
                val responses = {{methodName}}(requests)
                for (response in responses) {
                    onNext(response)
@@ -155,4 +155,6 @@ class {{serviceName}} @Inject constructor(
 }
 
 private fun cancelCoroutineScopeOnGrpcCancellation(scope: CoroutineScope) =
-  Context.current().addListener({ scope.cancel(CancellationException("Grpc context cancelled")) }, Runnable::run)
+  Context.current().addListener({
+    scope.cancel(CancellationException(null, GrpcContextWasCancelled()))
+  }, Runnable::run)

--- a/grpc-kotlin-gen/src/main/resources/Service.mustache
+++ b/grpc-kotlin-gen/src/main/resources/Service.mustache
@@ -59,11 +59,14 @@ class {{serviceName}} @Inject constructor(
         val requestData = GrpcKeepRequestDataInterceptor.getKeptRequestData()
         coroutineScope.launch(GrpcContextCoroutineContextElement()) {
             this.doCancelScopeWhenGrpcContextCancelled()
-            tryCatchingStatus(responseObserver) {
-                val handler = {{methodName}}ComponentFactory.create(requestData)
-                                .provideHandler()
-                val response = handler.invoke(request)
-                onNext(response)
+            try {
+               val handler = {{methodName}}ComponentFactory.create(requestData)
+                      .provideHandler()
+               val response = handler.invoke(request)
+               responseObserver.onNext(response)
+               responseObserver.onCompleted()
+            } catch (t: Throwable) {
+               responseObserver.onError(t.orCancellationCause())
             }
         }
     }
@@ -79,11 +82,14 @@ class {{serviceName}} @Inject constructor(
         val requestData = GrpcKeepRequestDataInterceptor.getKeptRequestData()
         coroutineScope.launch(GrpcContextCoroutineContextElement()) {
             this.doCancelScopeWhenGrpcContextCancelled()
-            tryCatchingStatus(responseObserver) {
-                val handler = {{methodName}}ComponentFactory.create(requestData)
+            try {
+               val handler = {{methodName}}ComponentFactory.create(requestData)
                                  .provideHandler()
-                produce<{{outputType}}> { handler.invoke(request, this) }
-                  .consumeEach(::onNext)
+               produce<{{outputType}}> { handler.invoke(request, this) }
+                  .consumeEach(responseObserver::onNext)
+               responseObserver.onCompleted()
+            } catch (t: Throwable) {
+               responseObserver.onError(t.orCancellationCause())
             }
         }
     }
@@ -103,9 +109,12 @@ class {{serviceName}} @Inject constructor(
         val requests = StreamObserverChannel<{{inputType}}>()
         coroutineScope.launch(GrpcContextCoroutineContextElement()) {
             this.doCancelScopeWhenGrpcContextCancelled()
-            tryCatchingStatus(responseObserver) {
-                val response = {{methodName}}(requests)
-                onNext(response)
+            try {
+               val response = {{methodName}}(requests)
+               responseObserver.onNext(response)
+               responseObserver.onCompleted()
+            } catch (t: Throwable) {
+               responseObserver.onError(t.orCancellationCause())
             }
         }
         return requests
@@ -123,11 +132,14 @@ class {{serviceName}} @Inject constructor(
         val requests = StreamObserverChannel<{{inputType}}>()
         coroutineScope.launch(GrpcContextCoroutineContextElement()) {
             this.doCancelScopeWhenGrpcContextCancelled()
-            tryCatchingStatus(responseObserver) {
-                val responses = {{methodName}}(requests)
-                for (response in responses) {
-                    onNext(response)
-                }
+            try {
+               val responses = {{methodName}}(requests)
+               for (response in responses) {
+                   onNext(response)
+               }
+               responseObserver.onCompleted()
+            } catch (t: Throwable) {
+               responseObserver.onError(t.orCancellationCause())
             }
         }
         return requests
@@ -141,20 +153,12 @@ class {{serviceName}} @Inject constructor(
             .withDescription("Method ${methodDescriptor.fullMethodName} is unimplemented")
     }
 
-    private fun <E> handleException(t: Throwable, responseObserver: StreamObserver<E>) {
-        when (t) {
-          is CancellationException -> responseObserver.onError(t.cause ?: RuntimeException("Cancellation without cause"))
-          else -> responseObserver.onError(t)
-        }
-    }
-
-    private suspend fun <E> tryCatchingStatus(responseObserver: StreamObserver<E>, body: suspend StreamObserver<E>.() -> Unit) {
-        try {
-            responseObserver.body()
-            responseObserver.onCompleted()
-        } catch (t: Throwable) {
-            handleException(t, responseObserver)
-        }
+    private fun Throwable.orCancellationCause() : Throwable {
+       val _cause = this.cause
+       if (this is CancellationException && _cause != null) {
+          return _cause
+       }
+       return this
     }
 }
 


### PR DESCRIPTION
Handling of a unary call

```kotlin
final override fun getEmployerChatUi(request: proto.frontend.employer.chat.GetEmployerChatUiRequest, responseObserver: StreamObserver<proto.frontend.employer.chat.EmployerChatUi>) {
        coroutineScope.launch(GrpcContextCoroutineContextElement()) {
            try {
               cancelCoroutineScopeOnGrpcCancellation(scope = this)
               val requestData = KeepRequestDataInContextInterceptor.getRequestData()
               val handler = getEmployerChatUiComponentFactory.create(requestData)
                      .provideHandler()
               val response = handler.invoke(request)
               responseObserver.onNext(response)
               responseObserver.onCompleted()
            } catch (t: Throwable) {
               responseObserver.onError(t)
            }
        }
    }
```

Handling of a server streaming call

```kotlin
  final override fun streamEmployerChatUpdates(request: proto.frontend.common.chat.StreamChatUpdatesRequest, responseObserver: StreamObserver<proto.frontend.common.chat.ChatUpdate>) {
        coroutineScope.launch(GrpcContextCoroutineContextElement()) {
            try {
               cancelCoroutineScopeOnGrpcCancellation(scope = this)
               val requestData = KeepRequestDataInContextInterceptor.getRequestData()
               val handler = streamEmployerChatUpdatesComponentFactory.create(requestData)
                                 .provideHandler()
               produce<proto.frontend.common.chat.ChatUpdate> { handler.invoke(request, this) }
                  .consumeEach(responseObserver::onNext)
               responseObserver.onCompleted()
            } catch (e: Throwable) {
               if (e is CancellationException && e.cause is GrpcContextWasCancelled) {
                  responseObserver.onCompleted()
               } else {
                  responseObserver.onError(e)
               }
            }
        }
    }
```
